### PR TITLE
Logik zum zurücksetzen von Skills im Skillbaum implementiert

### DIFF
--- a/Hero.Server.Core/Exceptions/NodeNotResettable.cs
+++ b/Hero.Server.Core/Exceptions/NodeNotResettable.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace Hero.Server.Core.Exceptions
+{
+
+	[Serializable]
+	public class NodeNotResettableException : HeroException
+	{
+		public NodeNotResettableException(string message) : base(message) { }
+		public NodeNotResettableException(string message, Exception inner) : base(message, inner) { }
+		protected NodeNotResettableException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+	}
+}

--- a/Hero.Server.Core/Extensions/NodeExtensions.cs
+++ b/Hero.Server.Core/Extensions/NodeExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Hero.Server.Core.Models;
+
+namespace Hero.Server.Core.Extensions
+{
+    public static class NodeExtensions
+    {
+        public static bool IsNodeResettable(this SkilltreeNode node)
+        {
+            return null != node.UnlockedAt && node.UnlockedAt > DateTime.UtcNow.AddMinutes(-5);
+        }
+    }
+}

--- a/Hero.Server.Core/Extensions/SkilltreeExtensions.cs
+++ b/Hero.Server.Core/Extensions/SkilltreeExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Hero.Server.Core.Models;
+﻿using Hero.Server.Core.Exceptions;
+using Hero.Server.Core.Models;
 
 namespace Hero.Server.Core.Extensions
 {
@@ -18,6 +19,54 @@ namespace Hero.Server.Core.Extensions
                 : tree.Nodes.Where(node => nodeToCheck.Precessors.Contains(node.Id)).All(node => node.IsUnlocked);
 
             return 0 == nodeToCheck.Precessors.Count || isUnlockable;
+        }
+
+
+        public static List<SkilltreeNode> GetAllNodesToReset(this Skilltree tree, Guid nodeId, List<SkilltreeNode>? nodes = null)
+        {
+            SkilltreeNode nodeToCheck = tree.Nodes.Single(node => nodeId == node.Id);
+
+            if (nodes?.Contains(nodeToCheck) ?? false)
+            {
+                return nodes;
+            }
+
+            if (!nodeToCheck.IsNodeResettable())
+            {
+                throw new NodeNotResettableException($"The node '{nodeId}' is not resettable.");
+            }
+
+            List<SkilltreeNode> nodesToReset = nodes ?? new();
+            nodesToReset.Add(nodeToCheck);
+            List<SkilltreeNode> successors = tree.Nodes.Where(node => nodeToCheck.Successors.Contains(node.Id) && node.IsUnlocked).ToList();
+
+            if (successors.Any())
+            {
+                foreach (SkilltreeNode successor in successors)
+                {
+                    if (successor.Precessors.Count == 1)
+                    {
+                        nodesToReset.AddRange(tree.GetAllNodesToReset(successor.Id, nodesToReset));
+                    }
+                    else if (successor.Precessors.Count > 1)
+                    {
+                        if (!successor.IsEasyReachable)
+                        {
+                            nodesToReset.AddRange(tree.GetAllNodesToReset(successor.Id, nodesToReset));
+                        }
+                        else 
+                        {
+                            List<SkilltreeNode> otherUnlockedPressesors = tree.Nodes.Where(node => node.IsUnlocked && successor.Precessors.Where(id => id != nodeToCheck.Id).Contains(node.Id)).ToList();
+                            if (otherUnlockedPressesors.All(node => nodesToReset.Contains(node)))
+                            {
+                                nodesToReset.AddRange(tree.GetAllNodesToReset(successor.Id, nodesToReset));
+                            }
+                        }
+                    }
+                }
+            }
+
+            return nodesToReset;
         }
     }
 }

--- a/Hero.Server.Core/Models/Node.cs
+++ b/Hero.Server.Core/Models/Node.cs
@@ -33,5 +33,6 @@
     public class SkilltreeNode : Node
     {
         public bool IsUnlocked { get; set; }
+        public DateTime? UnlockedAt { get; set; }
     }
 }

--- a/Hero.Server.Core/Repositories/ISkilltreeRepository.cs
+++ b/Hero.Server.Core/Repositories/ISkilltreeRepository.cs
@@ -12,5 +12,6 @@ namespace Hero.Server.Core.Repositories
         Task UnlockNode(Guid skilltreeId, Guid nodeId, CancellationToken token = default);
         Task<int> GetSkillpoints(Guid skilltreeId, CancellationToken token = default);
         Task ResetSkilltreeAsync(Guid skilltreeId, CancellationToken cancellationToken = default);
+        Task ResetNode(Guid skilltreeId, Guid nodeId, CancellationToken token = default);
     }
 }

--- a/Hero.Server.DataAccess/Migrations/20221202121309_AddUnlockedAtForSkilltreeNodes.Designer.cs
+++ b/Hero.Server.DataAccess/Migrations/20221202121309_AddUnlockedAtForSkilltreeNodes.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Hero.Server.DataAccess.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Hero.Server.DataAccess.Migrations
 {
     [DbContext(typeof(HeroDbContext))]
-    partial class HeroDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221202121309_AddUnlockedAtForSkilltreeNodes")]
+    partial class AddUnlockedAtForSkilltreeNodes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Hero.Server.DataAccess/Migrations/20221202121309_AddUnlockedAtForSkilltreeNodes.cs
+++ b/Hero.Server.DataAccess/Migrations/20221202121309_AddUnlockedAtForSkilltreeNodes.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hero.Server.DataAccess.Migrations
+{
+    public partial class AddUnlockedAtForSkilltreeNodes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UnlockedAt",
+                schema: "Hero",
+                table: "SkilltreeNodes",
+                type: "timestamp with time zone",
+                defaultValueSql: "now()",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UnlockedAt",
+                schema: "Hero",
+                table: "SkilltreeNodes");
+        }
+    }
+}

--- a/Hero.Server/Controllers/SkilltreesController.cs
+++ b/Hero.Server/Controllers/SkilltreesController.cs
@@ -85,9 +85,16 @@ namespace Hero.Server.Controllers
         }
 
         [HttpPost("{skilltreeId}/nodes/{nodeId}/unlock")]
-        public async Task<IActionResult> UnlockNode(Guid skilltreeId, Guid nodeId, CancellationToken token)
+        public async Task<IActionResult> UnlockNodeAsync(Guid skilltreeId, Guid nodeId, CancellationToken token)
         {
             await this.repository.UnlockNode(skilltreeId, nodeId, token);
+            return this.Ok();
+        }
+
+        [HttpPost("{skilltreeId}/nodes/{nodeId}/reset")]
+        public async Task<IActionResult> ResetNodeAsync(Guid skilltreeId, Guid nodeId, CancellationToken token)
+        {
+            await this.repository.ResetNode(skilltreeId, nodeId, token);
             return this.Ok();
         }
 

--- a/Hero.Server/Messages/Responses/NodeResponse.cs
+++ b/Hero.Server/Messages/Responses/NodeResponse.cs
@@ -18,6 +18,7 @@
     public class SkilltreeNodeResponse : NodeResponse
     {
         public bool IsUnlocked { get; set; }
+        public DateTime? UnlockedAt { get; set; }
     }
 
     public class BlueprintNodeResponse : NodeResponse


### PR DESCRIPTION
Skills können von Spielern zurückgesetzt werden, wenn:
- Der Freischaltzeitpunkt nicht länger als 5 Minuten her ist
- Alle nachfolgenden Skills auch Zurücksetzbar sind
Es werden alle nachfolgenden Skills zurückgesetzt, die davon abhängig sind, dass der zurückzusetzende Skill freigeschalten ist.